### PR TITLE
Fixing example code

### DIFF
--- a/example/sio-list-devices/Program.cs
+++ b/example/sio-list-devices/Program.cs
@@ -56,7 +56,7 @@ namespace SoundIOSharp.Example
 				PrintDevice (api.GetInputDevice (i));
 			Console.WriteLine ("Outputs");
 			for (int i = 0; i < api.OutputDeviceCount; i++)
-				PrintDevice (api.GetInputDevice (i));
+				PrintDevice (api.GetOutputDevice (i));
 		}
 
 		static void PrintDevice (SoundIODevice dev)


### PR DESCRIPTION
Print device calls for input and output devices were being called with
the input device list.  Fixing this.